### PR TITLE
WIP: Update scaife-stack for other data sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Here are two approaches that can be used to manage ATLAS data for a project:
 **2) Manage data externally**
 
 - The data sets for `scaife-stack` use data tracked in [explorehomer-atlas](https://github.com/scaife-viewer/explorehomer-atlas)
-- The `fetch-explorehomer-data` script is used to retrieve data to a temporary directory
+- The `fetch-repo-tarball` script is used to retrieve data to a temporary directory
 - The `stage_atlas_data` management command is used to stage the data for ingestion
 
 The `prepare-atlas-data.sh` script can be used to load the explorehomer-atlas data into `scaife-stack`:

--- a/backend/README.md
+++ b/backend/README.md
@@ -15,7 +15,7 @@ pip install -r requirements-dev.txt
 
 Retrieve content from the explorehomer-atlas repository:
 ```
-./scripts/fetch-explorehomer-data.sh
+./scripts/fetch-repo-tarball.sh
 ```
 
 Stage the ATLAS data directory:

--- a/backend/scaife_stack_atlas/management/commands/stage_atlas_data.py
+++ b/backend/scaife_stack_atlas/management/commands/stage_atlas_data.py
@@ -42,7 +42,7 @@ class Command(BaseCommand):
             return [x for x in p.iterdir() if x.is_dir()]
         except FileNotFoundError:
             self.stderr.write(
-                f"{tmp_path} was not found; run fetch-explorehomer-data to create it"
+                f"{tmp_path} was not found; run fetch-repo-tarball to create it"
             )
             return []
 
@@ -50,7 +50,7 @@ class Command(BaseCommand):
         atlas_conf_path = next(repo_dir.glob("atlas.yaml"), None)
         if not atlas_conf_path:
             self.stdout.write(
-                "{repo_dir.name} does not contain an ATLAS configuration file"
+                f"{repo_dir.name} does not contain an ATLAS configuration file"
             )
             return
 

--- a/backend/scripts/fetch-repo-tarball.sh
+++ b/backend/scripts/fetch-repo-tarball.sh
@@ -4,8 +4,10 @@ set -e
 mkdir -p data-tmp
 cd data-tmp
 
-GH_REPO_NAME="${GH_REPO_NAME:-scaife-viewer/explorehomer-atlas}"
-GIT_REF="${GIT_REF:-feature/atlas-yml}"
+ATLAS_DATA_REPO="${ATLAS_DATA_REPO:-scaife-viewer/explorehomer-atlas}"
+ATLAS_DATA_REPO_REF="${ATLAS_DATA_REPO_REF:-feature/atlas-yml}"
 
-curl -L "https://github.com/${GH_REPO_NAME}/archive/${GIT_REF}.tar.gz"  | tar zxf -
-echo "Downloaded contents of ${GH_REPO_NAME} at ${GIT_REF}"
+TARBALL_URL="https://github.com/${ATLAS_DATA_REPO}/archive/${ATLAS_DATA_REPO_REF}.tar.gz"
+echo "Retrieving $TARBALL_URL"
+curl -L "${TARBALL_URL}" | tar zxf -
+echo "Downloaded and untarred contents of ${ATLAS_DATA_REPO} at ${ATLAS_DATA_REPO_REF}"

--- a/backend/scripts/fetch-repo-tarball.sh
+++ b/backend/scripts/fetch-repo-tarball.sh
@@ -4,8 +4,8 @@ set -e
 mkdir -p data-tmp
 cd data-tmp
 
-GH_REPO_NAME="scaife-viewer/explorehomer-atlas"
-GIT_REF="feature/atlas-yml"
+GH_REPO_NAME="${GH_REPO_NAME:-scaife-viewer/explorehomer-atlas}"
+GIT_REF="${GIT_REF:-feature/atlas-yml}"
 
 curl -L "https://github.com/${GH_REPO_NAME}/archive/${GIT_REF}.tar.gz"  | tar zxf -
 echo "Downloaded contents of ${GH_REPO_NAME} at ${GIT_REF}"

--- a/backend/scripts/prepare-atlas-data.sh
+++ b/backend/scripts/prepare-atlas-data.sh
@@ -2,7 +2,7 @@
 set -e
 
 echo "[Fetching ATLAS data]"
-sh ./scripts/fetch-explorehomer-data.sh
+sh ./scripts/fetch-repo-tarball.sh
 
 echo "[Stage data]"
 python manage.py stage_atlas_data --rebuild

--- a/heroku.dockerfile
+++ b/heroku.dockerfile
@@ -41,6 +41,8 @@ COPY ./backend .
 
 ARG HEROKU_APP_NAME
 
+ARG ATLAS_DATA_REPO
+ARG ATLAS_DATA_REPO_REF
 RUN sh scripts/prepare-atlas-data.sh
 
 RUN python manage.py loaddata fixtures/sites.json

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,5 +1,8 @@
 build:
   docker:
     web: heroku.dockerfile
+  config:
+    ATLAS_DATA_REPO: "jacobwegner/dunsany"
+    ATLAS_DATA_REPO_REF: "atlas-metadata"
 run:
   web: gunicorn scaife_stack_atlas.wsgi


### PR DESCRIPTION
To load from [jacobwegner/dunsany](https://github.com/jacobwegner/dunsany)...

_Via Docker (assumes that the `atlas` service is running)_:

```shell
docker-compose exec atlas sh
export ATLAS_DATA_REPO=jacobwegner/dunsany
export ATLAS_DATA_REPO_REF=atlas-metadata
./scripts/prepare-atlas-data.sh
```

or within the `backend` virtualenv:
```
export ATLAS_DATA_REPO =jacobwegner/dunsany
export ATLAS_DATA_REPO_REF =atlas-metadata
./scripts/prepare-atlas-data.sh
```

I've stubbed out some steps in #2 to work with a local copy; basically, `fetch-repo-tarball` dumps the repo tarball into `data-tmp/<repo-name>`, and then the `stage_atlas_data` script moves around the data files.

The branch will get auto-deployed on Heroku as well.  To override the `ATLAS_DATA_REPO*` env var on Heroku, edit the values in heroku.yml:

```yaml
build:
  docker:
    web: heroku.dockerfile
  config:
    ATLAS_DATA_REPO: "jacobwegner/dunsany"
    ATLAS_DATA_REPO_REF: "atlas-metadata"
```

https://scaife-stack-pr-3.herokuapp.com/